### PR TITLE
修复了生成配置时url多出的冒号

### DIFF
--- a/server/hy2.sh
+++ b/server/hy2.sh
@@ -1916,7 +1916,7 @@ generate_client_config(){
 	if [ "${portHoppingStatus}" == "true" ];then
 		url_base="${url_base}${port}/?mport=${portHoppingStart}-${portHoppingEnd}&"
 	else
-		url_base="${url_base}:${port}/?"
+		url_base="${url_base}${port}/?"
 	fi
 	
 	if [ "${insecure}" == "true" ];then


### PR DESCRIPTION
在配置填写完毕生成时，菜单2的url在域名和端口处会多出一个冒号导致url出错，并且因为`generate_qr()`使用的参数来自`generate_client_config()`即生成配置时的错误参数，所以也导致二维码同样有问题。

![image](https://github.com/user-attachments/assets/e7c85155-fd26-4bae-91c4-ac1c4e09b3a0)
